### PR TITLE
Preferences path handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -900,9 +900,11 @@ class THICKET_Pref(AddonPreferences):
 
         box = self.layout.box()
         box.label(text="Laubwerk Plants Library")
-        row = box.row()
-        row.alert = not thicket_ready
-        row.prop(self, "lbw_path")
+        col = box.column()
+        col.alert = not thicket_ready
+        col.prop(self, "lbw_path")
+        if not thicket_ready:
+            col.label(text="Verify the 'Install Path' includes both a 'Plants' and a 'Python' directory.")
 
         lbw_version = "Laubwerk Version: N/A"
         db_status = "No database found"
@@ -910,14 +912,13 @@ class THICKET_Pref(AddonPreferences):
             lbw_version = laubwerk.version
             db_status = "Database contains %d plants" % db.plant_count()
 
+        box.label(text=lbw_version)
         row = box.row()
-        row.enabled = thicket_ready
-        row.label(text=lbw_version)
-
-        row = box.row()
-        row.enabled = thicket_ready
-        row.label(text=db_status)
-        row.operator("thicket.rebuild_db", icon="FILE_REFRESH")
+        col = row.column()
+        col.label(text=db_status)
+        col = row.column()
+        col.enabled = thicket_ready
+        col.operator("thicket.rebuild_db", icon="FILE_REFRESH")
 
 
 __classes__ = (

--- a/__init__.py
+++ b/__init__.py
@@ -186,7 +186,8 @@ def thicket_init():
 
     valid_lbw_path = False
     lbw_path = bpy.context.preferences.addons[__name__].preferences.lbw_path
-    if lbw_path and Path(lbw_path).is_dir():
+
+    if lbw_path != "" and Path(lbw_path).is_dir():
         plants_path = Path(lbw_path) / "Plants"
         sdk_path = Path(lbw_path) / "Python"
         if plants_path.is_dir() and sdk_path.is_dir():
@@ -195,7 +196,7 @@ def thicket_init():
     if not valid_lbw_path:
         plants_path = None
         sdk_path = None
-        logging.warning("Invalid Laubwerk Install Path: %s" % lbw_path)
+        logging.warning("Invalid Laubwerk Install Path: '%s'" % lbw_path)
         return
 
     if str(sdk_path) not in sys.path:
@@ -884,7 +885,10 @@ class THICKET_Pref(AddonPreferences):
     bl_idname = __name__
 
     def lbw_path_on_update(self, context):
-        self["lbw_path"] = str(Path(self.lbw_path).resolve())
+        logging.debug("Blender relative Laubwerk Install path: '%s'" % self.lbw_path)
+        if self.lbw_path != "":
+            self["lbw_path"] = str(Path(bpy.path.abspath(self.lbw_path)).resolve())
+            logging.debug("Absolute Laubwerk Install path: '%s'" % self.lbw_path)
         thicket_init()
 
     lbw_path: StringProperty(


### PR DESCRIPTION
Make Laubwerk Install path handling more robust across platforms and account for the Blender relative path format. Update the Preferences panel to provide the user with some guidance if things fail.