### PR TITLE
Index database by plant name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -269,7 +269,7 @@ def thicket_init():
     except FileNotFoundError:
         logging.info("Database not found, creating empty database")
 
-    if db is None:
+    if db is None or db.plant_count() == 0:
         thicket_status = ThicketStatus.REBUILD_DB
         db_dir = Path(PurePath(db_path).parent)
         db_dir.mkdir(parents=True, exist_ok=True)
@@ -874,6 +874,11 @@ class THICKET_PT_plant_properties(Panel):
             return
 
         plant = db.get_plant(name=tp.name)
+        if plant is None:
+            layout.label(text="Plant not found in database")
+            layout.operator("thicket.rebuild_db", icon="FILE_REFRESH")
+            return
+
         layout.template_icon(icon_value=get_preview(plant.name, tp.model).icon_id, scale=THICKET_SCALE)
         if thicket_ui_mode == 'VIEW':
             o = layout.operator("thicket.edit_plant")

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -162,10 +162,20 @@ class ThicketDB:
         except KeyError:
             return key
 
-    def get_plant(self, filepath):
-        if filepath not in self._db["plants"]:
-            return None
-        return DBPlant(self, filepath)
+    def get_plant(self, filepath=None, name=None):
+        if filepath:
+            if filepath not in self._db["plants"]:
+                filepath = None
+
+        if filepath is None and name:
+            for f in self._db["plants"]:
+                if self._db["plants"][f]["name"] == name:
+                    filepath = f
+
+        if filepath:
+            return DBPlant(self, filepath)
+
+        return None
 
     def add_plant(self, plant_filename):
         p_rec = ThicketDB.parse_plant(plant_filename)

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -97,6 +97,11 @@ class DBIter:
         raise StopIteration
 
 
+class ThicketDBOldSchemaError(Exception):
+    # TODO: include current and read schema version
+    pass
+
+
 class ThicketDB:
     """ Thicket Database Interface """
     def __init__(self, db_filename, locale="en-US", python=sys.executable, create=False):
@@ -107,8 +112,9 @@ class ThicketDB:
         try:
             with open(db_filename, "r", encoding="utf-8") as f:
                 self._db = json.load(f)
-            if self._db["info"]["schema_version"] != SCHEMA_VERSION:
+            if self._db["info"]["schema_version"] < SCHEMA_VERSION:
                 logging.warning("Unknown database schema version")
+                raise ThicketDBOldSchemaError
         except FileNotFoundError:
             if create:
                 self.initialize()

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -293,7 +293,6 @@ def import_lbw(filepath, leaf_density, model, qualifier, viewport_lod,
     tp = plant_col.thicket
     tp.magic = THICKET_GUID
     tp.name = lbw_plant.name
-    tp.filepath = filepath
     tp.model = lbw_model.name
     tp.qualifier = qualifier
     tp.viewport_lod = viewport_lod


### PR DESCRIPTION
Without the file->import mechanism, indexing by filename no longer makes sense. It also encodes filenames in scenes which break when the plant library is moved or when used on a different machine. Keep that information in the database and out of the scene by indexing by plant name.

Handle some errors discovered through testing database schema upgrades, making the initialization more robust in general, and giving the user easy access to the rebuild db operator from the N Panel when needed.