### PR TITLE
Materials fixes

### DIFF
--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -154,6 +154,7 @@ def lbw_to_bl_mat_1033(plant, mat_id, mat_name, qualifier=None, proxy_color=None
     node_img = nodes.new(type='ShaderNodeTexImage')
     node_img.location = 0, 2 * NH
     node_img.image = bpy.data.images.load(diffuse_path)
+    links.new(node_img.outputs[0], node_dif.inputs[0])
 
     # Handle Two-Sided Textures (diffuse texture only)
     if lbw_mat.is_two_sided() and lbw_mat.sides_are_different():
@@ -170,8 +171,6 @@ def lbw_to_bl_mat_1033(plant, mat_id, mat_name, qualifier=None, proxy_color=None
         links.new(node_img.outputs[0], node_mix.inputs[1])
         links.new(node_back_img.outputs[0], node_mix.inputs[2])
         links.new(node_mix.outputs[0], node_dif.inputs[0])
-    else:
-        links.new(node_img.outputs[0], node_dif.inputs[0])
 
     # Alpha Texture
     # Blender render engines support using the diffuse map alpha channel. We
@@ -266,13 +265,29 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, qualifier=None, proxy_color=None):
     if proxy_color:
         return mat
 
-    # Diffuse Texture (FIXME: Assumes one sided)
+    # Diffuse Texture
     logging.debug("Diffuse Texture: %s" % lbw_mat.get_front().base_color_texture)
     diffuse_path = lbw_mat.get_front().base_color_texture
     node_img = nodes.new(type='ShaderNodeTexImage')
     node_img.location = 0, 2 * NH
     node_img.image = bpy.data.images.load(diffuse_path)
     links.new(node_img.outputs[0], node_dif.inputs[0])
+
+    # Handle Two-Sided Textures (diffuse texture only)
+    if lbw_mat.is_two_sided() and lbw_mat.sides_are_different():
+        logging.debug("Diffuse texture is two sided")
+        diffuse_back_path = lbw_mat.get_back().base_color_texture
+        node_back_img = nodes.new(type='ShaderNodeTexImage')
+        node_back_img.location = -NW, 2 * NH
+        node_back_img.image = bpy.data.images.load(diffuse_back_path)
+        node_mix = nodes.new(type='ShaderNodeMixRGB')
+        node_mix.location = NW, 2 * NH
+        node_geometry = nodes.new(type='ShaderNodeNewGeometry')
+        node_geometry.location = -NW, NH
+        links.new(node_geometry.outputs[6], node_mix.inputs[0])
+        links.new(node_img.outputs[0], node_mix.inputs[1])
+        links.new(node_back_img.outputs[0], node_mix.inputs[2])
+        links.new(node_mix.outputs[0], node_dif.inputs[0])
 
     # Alpha Texture
     # Blender render engines support using the diffuse map alpha channel. We

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -210,6 +210,10 @@ def lbw_to_bl_mat_1033(plant, mat_id, mat_name, qualifier=None, proxy_color=None
         else:
             logging.warning("Subsurface Depth > 0. Not supported.")
 
+    # Index of Refraction (IOR)
+    # All Laubwerk Materials default to 1.33 across host applications
+    node_dif.inputs['IOR'].default_value = 1.33
+
     # Bump Texture
     bump_path = lbw_mat.get_front().bump_texture
     if bump_path != "":
@@ -306,6 +310,10 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, qualifier=None, proxy_color=None):
             links.new(node_sub.outputs['Color'], node_dif.inputs['Transmission'])
         else:
             logging.warning("Subsurface scattering not supported on closed volumes.")
+
+    # Index of Refraction (IOR)
+    # All Laubwerk Materials default to 1.33 across host applications
+    node_dif.inputs['IOR'].default_value = 1.33
 
     # Bump Texture
     bump_path = lbw_mat.get_front().bump_texture


### PR DESCRIPTION
Address Issue #30 (Set IOR to 1.33) and restore two-sided materials which were inadvertently removed when addressing the Laubwerk 1.0.34 SDK update.

Improves handling of subsurface for thin-shells by introducing translucency instead of transmission. 