### PR TITLE
Get plugin to work again on Blender versions starting from 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+thicket.db
+thicket.log

--- a/__init__.py
+++ b/__init__.py
@@ -370,9 +370,11 @@ def select_plant(filepath, defaults=False):
     old_model = tp.model
     old_qual = tp.qualifier
 
-    if defaults:
-        for key in tp.keys():
-            tp.pop(key)
+    # FIXME: we still want to reset the operator but not this way
+    #if defaults:
+    #    #keys = tp.keys()
+    #    #for key in keys:
+    #    #    tp.pop(key)
 
     tp.name = plant.name
     if tp.batch_mode:

--- a/__init__.py
+++ b/__init__.py
@@ -370,11 +370,10 @@ def select_plant(filepath, defaults=False):
     old_model = tp.model
     old_qual = tp.qualifier
 
-    # FIXME: we still want to reset the operator but not this way
-    #if defaults:
-    #    #keys = tp.keys()
-    #    #for key in keys:
-    #    #    tp.pop(key)
+    if defaults:
+        keys = list(tp.keys())
+        for key in keys:
+           tp.pop(key)
 
     tp.name = plant.name
     if tp.batch_mode:

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -274,7 +274,7 @@ class ThicketDB:
         plant["filepath"] = filepath
         plant["md5"] = md5sum(filepath)
         plant["default_model"] = p.default_model.name
-        preview_stem = p.name.replace(" ", "_").replace(".", "")
+        preview_stem = p.plant_meta["botanical_name"].replace(" ", "_").replace(".", "")
         preview_path = Path(filepath).parent.absolute() / (preview_stem + ".png")
         if not preview_path.is_file():
             logger.warning("Preview not found: %s" % preview_path)

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -270,7 +270,7 @@ class ThicketDB:
         p_rec = {}
 
         plant = {}
-        plant["name"] = p.name
+        plant["name"] = p.plant_meta["name"]
         plant["filepath"] = filepath
         plant["md5"] = md5sum(filepath)
         plant["default_model"] = p.default_model.name
@@ -284,11 +284,9 @@ class ThicketDB:
         labels = {}
         p_labels = {}
         # Store only the first label per locale
-        #for label in p.labels.items():
-        #    p_labels[label[0]] = label[1][0]
-        for label in next(x for x in p.params[1]['enum']['options'] if x['name'] == p.name)['labels']:
-            p_labels[label['lang']] = label['text']
-            
+        for label in p.plant_meta['labels']:
+            if not label['lang'] in p_labels:
+                p_labels[label['lang']] = label['text']
 
         labels[p.name] = p_labels
 
@@ -301,7 +299,9 @@ class ThicketDB:
             q_labels[q['name']] = {}
             for q_lang in q['labels']:
                 q_labels[q['name']][q_lang['lang']] = q_lang['text']
+        default_season = p.params[0]['enum']['default']
 
+        # in laubwerk API called 'variants'
         for m in p.models:
             m_rec = {}
             #seasons = []
@@ -314,7 +314,7 @@ class ThicketDB:
             labels.update(q_labels)
             m_rec["index"] = i
             m_rec["qualifiers"] = seasons
-            m_rec["default_qualifier"] = m.default_qualifier
+            m_rec["default_qualifier"] = default_season
             preview_path = Path(filepath).parent.absolute() / "models" / (preview_stem + "_" + m.name + ".png")
             if not preview_path.is_file():
                 logger.warning("Preview not found: %s" % preview_path)
@@ -322,10 +322,11 @@ class ThicketDB:
             m_rec["preview"] = str(preview_path)
             models[m.name] = m_rec
             m_labels = {}
-            # FIXME: highly redundant
-            for label in m.labels.items():
-                m_labels[label[0]] = label[1][0]
+
+            for label in next(x for x in p.params[1]['enum']['options'] if x['name'] == m.name)['labels']:
+                m_labels[label['lang']] = label['text']
             labels[m.name] = m_labels
+
             i = i + 1
         plant["models"] = models
 

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -314,7 +314,7 @@ class ThicketDB:
             labels.update(q_labels)
             m_rec["index"] = i
             m_rec["qualifiers"] = seasons
-            m_rec["default_qualifier"] = default_season
+            m_rec["default_qualifier"] = seasons[default_season]
             preview_path = Path(filepath).parent.absolute() / "models" / (preview_stem + "_" + m.name + ".png")
             if not preview_path.is_file():
                 logger.warning("Preview not found: %s" % preview_path)

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -304,13 +304,6 @@ class ThicketDB:
         # in laubwerk API called 'variants'
         for m in p.models:
             m_rec = {}
-            #seasons = []
-            #q_labels = {}
-            #for q in m.qualifiers:
-            #    seasons.append(q)
-            #    q_labels[q] = {}
-            #    for q_lang in m.qualifier_labels[q].items():
-            #        q_labels[q][q_lang[0]] = q_lang[1][0]
             labels.update(q_labels)
             m_rec["index"] = i
             m_rec["qualifiers"] = seasons

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -284,21 +284,33 @@ class ThicketDB:
         labels = {}
         p_labels = {}
         # Store only the first label per locale
-        for label in p.labels.items():
-            p_labels[label[0]] = label[1][0]
+        #for label in p.labels.items():
+        #    p_labels[label[0]] = label[1][0]
+        for label in next(x for x in p.params[1]['enum']['options'] if x['name'] == p.name)['labels']:
+            p_labels[label['lang']] = label['text']
+            
+
         labels[p.name] = p_labels
 
         models = {}
         i = 0
+        seasons = []
+        q_labels = {}
+        for q in p.params[0]['enum']['options']:
+            seasons.append(q['name'])
+            q_labels[q['name']] = {}
+            for q_lang in q['labels']:
+                q_labels[q['name']][q_lang['lang']] = q_lang['text']
+
         for m in p.models:
             m_rec = {}
-            seasons = []
-            q_labels = {}
-            for q in m.qualifiers:
-                seasons.append(q)
-                q_labels[q] = {}
-                for q_lang in m.qualifier_labels[q].items():
-                    q_labels[q][q_lang[0]] = q_lang[1][0]
+            #seasons = []
+            #q_labels = {}
+            #for q in m.qualifiers:
+            #    seasons.append(q)
+            #    q_labels[q] = {}
+            #    for q_lang in m.qualifier_labels[q].items():
+            #        q_labels[q][q_lang[0]] = q_lang[1][0]
             labels.update(q_labels)
             m_rec["index"] = i
             m_rec["qualifiers"] = seasons

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -79,9 +79,12 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
 
     # String operations are expensive, do them here outside the material loop
     wood_mat_name = lbw_plant.name + " wood"
-    wood_color = lbw_plant.get_wood_color()
+    # FIXME: fetch proper preview colors somehow
+    wood_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
+ # lbw_plant.get_wood_color()
     foliage_mat_name = lbw_plant.name + " foliage"
-    foliage_color = lbw_plant.get_foliage_color()
+    foliage_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
+# lbw_plant.get_foliage_color()
 
     use_1033 = False
     lbw_version = laubwerk.version_info
@@ -93,7 +96,7 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
     # read matids and materialnames and create and add materials to the laubwerktree
     materials = []
     i = 0
-    for matID in zip(lbw_mesh.matids):
+    for matID in zip(lbw_mesh.mat_idxs):
         mat_id = matID[0]
         lbw_mat = lbw_plant.materials[mat_id]
         mat_name = lbw_mat.name

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -81,10 +81,8 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
     wood_mat_name = lbw_plant.name + " wood"
     # FIXME: fetch proper preview colors somehow
     wood_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
- # lbw_plant.get_wood_color()
     foliage_mat_name = lbw_plant.name + " foliage"
     foliage_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
-# lbw_plant.get_foliage_color()
 
     use_1033 = False
     lbw_version = laubwerk.version_info


### PR DESCRIPTION
Partially adresses #56. Laubwerk updated their API to support python 3.10/3.11 some time ago. This PR adapts to that and fixes just so much that the Plugin doesn't crash. It's just the bare minimum for now and we're working with Laubwerk on proper fixes.

## Workarounds and Bugs in this PR
- Material colors can't be extracted that easily anymore. We implemented raw values and are working on a solution
- There are still some fixes to be made: Proxy geometry, for example, doesn't work, but this PR ensure that at least partial and full geometry models can be generated.